### PR TITLE
chore: Remove required_fields_as_jsonld

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,32 +118,3 @@ def educational_input_kwargs(program_provider_address_data, offers, training_sal
         "start_date": "2020-04-01",
         "time_of_day": "Evening",
     }
-
-
-@pytest.fixture
-def required_fields_as_jsonld(work_based_input_kwargs):
-    return {
-        "@context": "http://schema.org/",
-        "@type": "WorkBasedProgram",
-        "description": work_based_input_kwargs['program_description'],
-        "name": work_based_input_kwargs['program_name'],
-        "url": work_based_input_kwargs['program_url'],
-        "provider": {
-            "@type": "EducationalOrganization",
-            "name": work_based_input_kwargs['provider_name'],
-            "address": [ 
-                {
-                    "@type": "PostalAddress", 
-                    "streetAddress": "1940 East Silverlake Rd",
-                    "addressLocality": "Tucson",
-                    "addressRegion": "AZ",
-                    "postalCode": "85713"
-                }
-            ],
-            "url": work_based_input_kwargs['provider_url'],
-            "contactPoint": {
-                "@type": "ContactPoint",
-                "telephone": work_based_input_kwargs['provider_telephone']
-            }
-        }
-    }

--- a/tests/education/test_main_education.py
+++ b/tests/education/test_main_education.py
@@ -8,6 +8,7 @@ from tests.conftest import pprint_diff
 
 
 def test_educational_occupational_converter_all(educational_input_kwargs, offers):
+    output = educational_occupational_programs_converter(educational_input_kwargs)
     expected_output = {
         "@context": "http://schema.org/",
         "@type": "EducationalOccupationalProgram",
@@ -72,11 +73,6 @@ def test_educational_occupational_converter_all(educational_input_kwargs, offers
         "timeOfDay": educational_input_kwargs["time_of_day"]
     }
 
-
-    output = educational_occupational_programs_converter(educational_input_kwargs)
-
-    pprint_diff(expected_output, output)
-
     json_expected_output = json.dumps(expected_output, sort_keys=True)
     json_output = json.dumps(output, sort_keys=True)
 
@@ -126,8 +122,6 @@ def test_educational_occupational_converter_recommended(educational_input_kwargs
     }
 
     output = educational_occupational_programs_converter(required_kwargs)
-
-    pprint_diff(expected_output, output)
 
     json_expected_output = json.dumps(expected_output, sort_keys=True)
     json_output = json.dumps(output, sort_keys=True)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -12,7 +12,6 @@ from tests.conftest import pprint_diff
 
 
 def test_add_basic_keywords(work_based_input_kwargs):
-
     kwarg_to_schema_key_mapper = {
         "program_description": "description",
         "program_name": "name",
@@ -138,52 +137,7 @@ def test_add_salary_upon_completion_data(salary_upon_completion):
 
 @pytest.mark.xfail
 def test_add_data_keywords(work_based_input_kwargs, required_fields_as_jsonld, offers, training_salary, salary_upon_completion):
-    # This test should not be an integration test?
-    data_keywords_mapper = {
-        "program_prerequisites": lambda output, value: add_prerequisites_data(output, kwargs['program_prerequisites']),
-        "offers_price": lambda output, kwargs: add_offers_data(output, kwargs['offers_price']),
-        "training_salary": lambda output, kwargs: add_training_salary_data(output, kwargs['training_salary']),
-        "salary_upon_completion": lambda output, kwargs: add_salary_upon_completion_data(output, kwargs['salary_upon_completion']),
-        "all": [
-            lambda output, kwargs: add_header(output, "WorkBasedProgram"),
-            lambda output, kwargs: add_provider_data(output, kwargs)
-        ]
-    }
-
-    recommend_fields = {
-        "programPrerequisites": [
-            {
-                "@type": "EducationalOccupationalCredential", 
-                "credentialCategory": "HighSchool"
-            },
-            {
-                "@type": "Text",
-                "eligibleGroups": "Youth"
-            },
-            {
-                "@type": "Text",
-                "maxIncomeEligibility": "20000"
-            },
-            {
-                "@type": "Text",
-                "otherProgramPrerequisites": "other"
-            }
-        ],
-        "offers": offers,
-        "trainingSalary": training_salary,
-        "salaryUponCompletion": salary_upon_completion
-    }
-    required_fields_as_jsonld.update(recommend_fields)
-    expected_output = required_fields_as_jsonld
-
-    output = add_data_keywords({}, work_based_input_kwargs, data_keywords_mapper)
-
-    pprint_diff(expected_output, output)
-
-    json_expected_output = json.dumps(expected_output, sort_keys=True)
-    json_output = json.dumps(output, sort_keys=True)
-
-    expect(json_output).to(equal(json_expected_output))
+    pass
 
 
 @pytest.mark.xfail

--- a/tests/work/test_main_work.py
+++ b/tests/work/test_main_work.py
@@ -5,52 +5,69 @@ from expects import equal, expect
 from tests.conftest import pprint_diff
 
 
-def test_work_based_programs_converter_all(work_based_input_kwargs, offers, training_salary, salary_upon_completion, required_fields_as_jsonld):
-    recommended_fields = {
+def test_work_based_programs_converter_all(work_based_input_kwargs, offers, training_salary, salary_upon_completion):
+    output = work_based_programs_converter(**work_based_input_kwargs)
+    expected_output = {
+        "@context": "http://schema.org/",
+        "@type": "WorkBasedProgram",
+        "name": work_based_input_kwargs['program_name'],
+        "description": work_based_input_kwargs['program_description'],
+        "url": work_based_input_kwargs["program_url"],
+        "offers": offers,
+        "provider": {
+            "@type": "EducationalOrganization",
+            "name": work_based_input_kwargs['provider_name'],
+            "address": [ 
+                {
+                    "@type": "PostalAddress", 
+                    "streetAddress": work_based_input_kwargs['provider_address'][0]['street_address'],
+                    "addressLocality": work_based_input_kwargs['provider_address'][0]['address_locality'],
+                    "addressRegion": work_based_input_kwargs['provider_address'][0]['address_region'],
+                    "postalCode": work_based_input_kwargs['provider_address'][0]['postal_code']
+                }
+            ],
+            "url": work_based_input_kwargs['provider_url'],
+            "contactPoint": {
+                "@type": "ContactPoint",
+                "telephone": work_based_input_kwargs['provider_telephone']
+            }
+        },
+        "timeToComplete": work_based_input_kwargs['time_to_complete'],
+        "endDate": work_based_input_kwargs['end_date'],
+        "startDate": work_based_input_kwargs['start_date'],
+        "maximumEnrollment": work_based_input_kwargs["maximum_enrollment"],
         "programPrerequisites": [
             {
                 "@type": "EducationalOccupationalCredential", 
-                "credentialCategory": "HighSchool"
+                "credentialCategory": work_based_input_kwargs["program_prerequisites"]["credential_category"]
             },
             {
                 "@type": "Text",
-                "eligibleGroups": "Youth"
+                "eligibleGroups": work_based_input_kwargs["program_prerequisites"]["eligible_groups"]
             },
             {
                 "@type": "Text",
-                "maxIncomeEligibility": "20000"
+                "maxIncomeEligibility": work_based_input_kwargs["program_prerequisites"]["max_income_eligibility"]
             },
             {
                 "@type": "Text",
-                "otherProgramPrerequisites": "other"
+                "otherProgramPrerequisites": work_based_input_kwargs["program_prerequisites"]["other_program_prerequisites"]
             }
         ],
-        "endDate": work_based_input_kwargs['end_date'],
-        "startDate": work_based_input_kwargs['start_date'],
-        "maximumEnrollment": work_based_input_kwargs['maximum_enrollment'],
-        "occupationalCredentialAwarded": work_based_input_kwargs['occupational_credential_awarded'],
-        "timeOfDay": work_based_input_kwargs['time_of_day'],
-        "timeToComplete": work_based_input_kwargs['time_to_complete'],
-        "offers": offers,
+        "timeOfDay": work_based_input_kwargs["time_of_day"],
         "trainingSalary": training_salary,
-        "salaryUponCompletion": salary_upon_completion
+        "salaryUponCompletion": salary_upon_completion,
+        "occupationalCredentialAwarded": work_based_input_kwargs["occupational_credential_awarded"],
     }
 
-    required_fields_as_jsonld.update(recommended_fields)
-
-    output = work_based_programs_converter(**work_based_input_kwargs)
-
-    pprint_diff(required_fields_as_jsonld, output)
-
-    json_expected_output = json.dumps(required_fields_as_jsonld, sort_keys=True)
+    json_expected_output = json.dumps(expected_output, sort_keys=True)
     json_output = json.dumps(output, sort_keys=True)
 
-    print(json.dumps(output, indent=4, sort_keys=True))
     expect(json_output).to(equal(json_expected_output))
 
 
-def test_work_based_programs_converter_required(work_based_input_kwargs, required_fields_as_jsonld):
-    kwargs = {
+def test_work_based_programs_converter_required(work_based_input_kwargs):
+    required_kwargs = {
         "program_description": work_based_input_kwargs['program_description'],
         "program_name": work_based_input_kwargs['program_name'],
         "program_url": work_based_input_kwargs['program_url'],
@@ -59,11 +76,35 @@ def test_work_based_programs_converter_required(work_based_input_kwargs, require
         "provider_telephone": work_based_input_kwargs['provider_telephone'],
         "provider_address": work_based_input_kwargs['provider_address']
     }
+    output = work_based_programs_converter(**required_kwargs)
 
-    output = work_based_programs_converter(**kwargs)
+    expected_output = {
+        "@context": "http://schema.org/",
+        "@type": "WorkBasedProgram",
+        "description": work_based_input_kwargs['program_description'],
+        "name": work_based_input_kwargs['program_name'],
+        "url": work_based_input_kwargs['program_url'],
+        "provider": {
+            "@type": "EducationalOrganization",
+            "name": work_based_input_kwargs['provider_name'],
+            "address": [ 
+                {
+                    "@type": "PostalAddress", 
+                    "streetAddress": work_based_input_kwargs['provider_address'][0]['street_address'],
+                    "addressLocality": work_based_input_kwargs['provider_address'][0]['address_locality'],
+                    "addressRegion": work_based_input_kwargs['provider_address'][0]['address_region'],
+                    "postalCode": work_based_input_kwargs['provider_address'][0]['postal_code']
+                }
+            ],
+            "url": work_based_input_kwargs['provider_url'],
+            "contactPoint": {
+                "@type": "ContactPoint",
+                "telephone": work_based_input_kwargs['provider_telephone']
+            }
+        }
+    }
 
-    pprint_diff(required_fields_as_jsonld, output)
-
-    json_expected_output = json.dumps(required_fields_as_jsonld, sort_keys=True)
+    json_expected_output = json.dumps(expected_output, sort_keys=True)
     json_output = json.dumps(output, sort_keys=True)
+    
     expect(json_output).to(equal(json_expected_output))


### PR DESCRIPTION
This PR removes the confusing fixture formerly known as `required_fields_as_jsonld`.