### PR TITLE
task: Revise logic for finding required fields

### DIFF
--- a/converter/converter.py
+++ b/converter/converter.py
@@ -21,7 +21,7 @@ class Converter():
         missing_kwargs = [kwarg for kwarg in self.required_keywords if kwarg not in kwargs.keys()]
 
         if missing_kwargs:
-            missing_kwargs_as_str = ", ".join(missing_kwargs)
+            missing_kwargs_as_str = ",".join(missing_kwargs)
             raise RuntimeError(f"One or more required properties needs to be included in the kwargs: {missing_kwargs_as_str}")
 
     def _add_basic_keywords(self, kwargs):

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -18,15 +18,11 @@ class Converter():
 
     def _check_for_required(self, kwargs):
         # TODO flatten kwargs and check all keys // BUT WE DONT NEED TO SUPPORT THIS
+        missing_kwargs = [kwarg for kwarg in self.required_keywords if kwarg not in kwargs.keys()]
 
-        def assert_required_keyword_is_in_kwargs(item):
-            try:
-                assert(item in kwargs)
-            except AssertionError:
-                raise RuntimeError("Required property not included")
-
-        for required_keyword in self.required_keywords:
-            assert_required_keyword_is_in_kwargs(required_keyword)
+        if missing_kwargs:
+            missing_kwargs_as_str = ", ".join(missing_kwargs)
+            raise RuntimeError(f"One or more required properties needs to be included in the kwargs: {missing_kwargs_as_str}")
 
     def _add_basic_keywords(self, kwargs):
         self.output = add_basic_keywords(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2,13 +2,12 @@ import pytest
 
 from converter.converter import Converter
 
-@pytest.mark.parametrize("input_kwargs,required_keyword,should_error", [
-    ({"a_recommended_keyword": "value"}, "a_required_keyword", True),
-    ({"a_required_keyword": "value"}, "a_required_keyword", False)
+@pytest.mark.parametrize("input_kwargs,required_keywords,should_error", [
+    ({"a_recommended_keyword": "value"}, ["a_required_keyword"], True),
+    ({"a_recommended_keyword": "value"}, ["a_required_keyword, another_required_keyword"], True),
+    ({"a_required_keyword": "value"}, ["a_required_keyword"], False)
 ])
-def test_check_for_required(input_kwargs,required_keyword, should_error):
-    required_keywords = [required_keyword]
-    
+def test_check_for_required(input_kwargs,required_keywords, should_error):
     converter = Converter(
         data_keywords_mapper={"all": []},
         kwarg_to_schema_key_mapper={},
@@ -18,9 +17,9 @@ def test_check_for_required(input_kwargs,required_keyword, should_error):
     if should_error:
         with pytest.raises(RuntimeError) as exceptionMsg:
             output = converter.trigger_conversion(input_kwargs)
-        
+
         assert "One or more required properties needs to be included in the kwargs" in str(exceptionMsg.value)
-        assert required_keyword in str(exceptionMsg.value)
+        assert ",".join(required_keywords) in str(exceptionMsg.value)
     else:
         output = converter.trigger_conversion(input_kwargs)
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,17 @@
+from converter.converter import Converter
+
+def test_converter_check_for_required(work_based_input_kwargs):
+    required_keywords = [
+        "program_description",
+        "program_name",
+        "program_url",
+        "provider_address",
+    ]
+    
+    converter = Converter(
+        data_keywords_mapper={},
+        kwarg_to_schema_key_mapper={},
+        required_keywords=required_keywords
+    )
+
+    converter.trigger_conversion(work_based_input_kwargs)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,17 +1,27 @@
+import pytest
+
 from converter.converter import Converter
 
-def test_converter_check_for_required(work_based_input_kwargs):
-    required_keywords = [
-        "program_description",
-        "program_name",
-        "program_url",
-        "provider_address",
-    ]
+@pytest.mark.parametrize("input_kwargs,required_keyword,should_error", [
+    ({"a_recommended_keyword": "value"}, "a_required_keyword", True),
+    ({"a_required_keyword": "value"}, "a_required_keyword", False)
+])
+def test_check_for_required(input_kwargs,required_keyword, should_error):
+    required_keywords = [required_keyword]
     
     converter = Converter(
-        data_keywords_mapper={},
+        data_keywords_mapper={"all": []},
         kwarg_to_schema_key_mapper={},
         required_keywords=required_keywords
     )
 
-    converter.trigger_conversion(work_based_input_kwargs)
+    if should_error:
+        with pytest.raises(RuntimeError) as exceptionMsg:
+            output = converter.trigger_conversion(input_kwargs)
+        
+        assert "One or more required properties needs to be included in the kwargs" in str(exceptionMsg.value)
+        assert required_keyword in str(exceptionMsg.value)
+    else:
+        output = converter.trigger_conversion(input_kwargs)
+
+        assert output == {}


### PR DESCRIPTION
# Overview

This PR revises `_check_for_required`. In the revision, we use list comprehension to determine if all values in `required_keywords` can be found in the keys of `kwargs`. This adjustment makes the code slightly more readable, and most importantly, it enables a more communicative error message.

Closes: https://app.clubhouse.io/brighthive/story/647/runtimeerror-required-property-not-included-does-not-give-information-about-the-required-keyword