### PR TITLE
Reginacompton/ch730/handle all required fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 .vscode/
+
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ You need to consider the following fields for the educational-occupational conve
 | provider_url          | String
 | provider_telephone    | String
 | time_to_complete      | String that represents a duration in ISO-8601 format
+| identifier_cip  AND/OR identifier_program_id                 | String
 | **RECOMMENDED FIELDS**                
-| identifier_cip                     | String
-| identifier_program_id              | String
 | application_start_date             | String
 | program_prerequisites              | A dict with any number of keywords, e.g., credential_category, eligible_groups, max_income_eligibility, other_program_prerequisites, etc.
 | start_date                         | String that represents a date in ISO-8601 format

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ You need to consider the following fields for the educational-occupational conve
 | provider_name         | String
 | provider_url          | String
 | provider_telephone    | String
-| time_to_complete      | String that represents a duration in ISO-8601 format
-| identifier_cip  AND/OR identifier_program_id                 | String
+| provider_telephone_contact_type    | String that describes the type of contact, e.g., "Admissions" or "Main Office" 
+| time_to_complete                   | String that represents a duration in ISO-8601 format
+| identifier_cip  AND/OR identifier_program_id | String
 | **RECOMMENDED FIELDS**                
 | application_start_date             | String
 | program_prerequisites              | A dict with any number of keywords, e.g., credential_category, eligible_groups, max_income_eligibility, other_program_prerequisites, etc.
@@ -66,6 +67,7 @@ You need to consider the following fields for the work-based converter: `work_ba
 | provider_name                      | String
 | provider_url                       | String
 | provider_telephone                 | String
+| provider_telephone_contact_type    | String that describes the type of contact, e.g., "Admissions" or "Main Office"
 | identifier_program_id              | String
 | program_prerequisites              | A dict with any number of keywords, e.g., credential_category, eligible_groups, max_income_eligibility, other_program_prerequisites, etc.
 | start_date                         | String that represents a date in ISO-8601 format

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ You need to consider the following fields for the educational-occupational conve
 | provider_name         | String
 | provider_url          | String
 | provider_telephone    | String
-| provider_telephone_contact_type    | String that describes the type of contact, e.g., "Admissions" or "Main Office" 
 | time_to_complete                   | String that represents a duration in ISO-8601 format
 | identifier_cip  AND/OR identifier_program_id | String
 | **RECOMMENDED FIELDS**                
@@ -67,7 +66,6 @@ You need to consider the following fields for the work-based converter: `work_ba
 | provider_name                      | String
 | provider_url                       | String
 | provider_telephone                 | String
-| provider_telephone_contact_type    | String that describes the type of contact, e.g., "Admissions" or "Main Office"
 | identifier_program_id              | String
 | program_prerequisites              | A dict with any number of keywords, e.g., credential_category, eligible_groups, max_income_eligibility, other_program_prerequisites, etc.
 | start_date                         | String that represents a date in ISO-8601 format

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -16,12 +16,12 @@ class Converter():
         return self.output
 
     def _check_for_required(self, kwargs):
-        # TODO flatten kwargs and check all keys // BUT WE DONT NEED TO SUPPORT THIS
         missing_kwargs = [kwarg for kwarg in self.required_keywords if kwarg not in kwargs.keys()]
 
         if missing_kwargs:
             missing_kwargs_as_str = ",".join(missing_kwargs)
-            raise RuntimeError(f"One or more required properties needs to be included in the kwargs: {missing_kwargs_as_str}")
+            raise ValueError(f"Missing kwargs! One or more required properties needs to be included in the kwargs: {missing_kwargs_as_str}")
+    
 
     def _add_basic_keywords(self, kwargs):
         self.output = add_basic_keywords(

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -16,12 +16,21 @@ class Converter():
         return self.output
 
     def _check_for_required(self, kwargs):
-        missing_kwargs = [kwarg for kwarg in self.required_keywords if kwarg not in kwargs.keys()]
+        '''
+        This function checks two things:
+        (1) the kwargs contain all required fields
+        (2) all required fields have a value – Google pathways does not consider an empty string to be valid input.
+        '''
+        missing_kwargs = []
+        for kwarg in self.required_keywords:
+            if kwarg not in kwargs.keys():
+                missing_kwargs.append(kwargs)
+            elif kwargs[kwarg] == '' or kwargs[kwarg] == None:
+                missing_kwargs.append(kwarg)
 
         if missing_kwargs:
             missing_kwargs_as_str = ",".join(missing_kwargs)
-            raise ValueError(f"Missing kwargs! One or more required properties needs to be included in the kwargs: {missing_kwargs_as_str}")
-    
+            raise ValueError(f"Missing kwargs! Please include values for the following fields: {missing_kwargs_as_str}")
 
     def _add_basic_keywords(self, kwargs):
         self.output = add_basic_keywords(

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -1,8 +1,11 @@
 from converter.helper import add_basic_keywords, add_data_keywords
 
 class Converter():
-    def __init__(self, data_keywords_mapper, kwarg_to_schema_key_mapper, additional_required_keywords=[]):
-        self.required_keywords = ["provider_address", "program_name", "program_description", "program_url"] + additional_required_keywords
+    def __init__(self, data_keywords_mapper, kwarg_to_schema_key_mapper, required_keywords=[]):
+        if type(required_keywords) is str:
+            required_keywords = required_keywords.replace(' ', '').split(',')
+
+        self.required_keywords = required_keywords
         self.data_keywords_mapper = data_keywords_mapper
         self.kwarg_to_schema_key_mapper = kwarg_to_schema_key_mapper
 
@@ -29,7 +32,7 @@ class Converter():
                 missing_kwargs.append(kwarg)
 
         if missing_kwargs:
-            missing_kwargs_as_str = ",".join(missing_kwargs)
+            missing_kwargs_as_str = ", ".join(missing_kwargs)
             raise ValueError(f"Missing kwargs! Please include values for the following fields: {missing_kwargs_as_str}")
 
     def _add_basic_keywords(self, kwargs):

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -24,7 +24,7 @@ class Converter():
         missing_kwargs = []
         for kwarg in self.required_keywords:
             if kwarg not in kwargs.keys():
-                missing_kwargs.append(kwargs)
+                missing_kwargs.append(kwarg)
             elif kwargs[kwarg] == '' or kwargs[kwarg] == None:
                 missing_kwargs.append(kwarg)
 

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -1,8 +1,8 @@
 from converter.helper import add_basic_keywords, add_data_keywords
 
 class Converter():
-    def __init__(self, data_keywords_mapper, kwarg_to_schema_key_mapper, required_keywords):
-        self.required_keywords = ["provider_address", "program_name", "program_url"] + required_keywords
+    def __init__(self, data_keywords_mapper, kwarg_to_schema_key_mapper, required_keywords=[]):
+        self.required_keywords = ["provider_address", "program_name", "program_description", "program_url"] + required_keywords
         self.data_keywords_mapper = data_keywords_mapper
         self.kwarg_to_schema_key_mapper = kwarg_to_schema_key_mapper
 

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -1,8 +1,8 @@
 from converter.helper import add_basic_keywords, add_data_keywords
 
 class Converter():
-    def __init__(self, data_keywords_mapper, kwarg_to_schema_key_mapper, required_keywords=[]):
-        self.required_keywords = ["provider_address", "program_name", "program_description", "program_url"] + required_keywords
+    def __init__(self, data_keywords_mapper, kwarg_to_schema_key_mapper, additional_required_keywords=[]):
+        self.required_keywords = ["provider_address", "program_name", "program_description", "program_url"] + additional_required_keywords
         self.data_keywords_mapper = data_keywords_mapper
         self.kwarg_to_schema_key_mapper = kwarg_to_schema_key_mapper
 

--- a/converter/education/educational_occupational_programs_converter.py
+++ b/converter/education/educational_occupational_programs_converter.py
@@ -4,8 +4,8 @@ from converter.helper import (add_header, add_offers_data,
                               add_salary_upon_completion_data,
                               add_training_salary_data, add_identifier_data)
 
-# A list of keywords that MUST be included in the source data, i.e., the data passed in a kwargs.
-required_keywords = [
+# A list of keywords required in particular for EducationalOccupationPrograms.
+additional_required_keywords = [
     "application_deadline",
     "offers_price", 
     "provider_name", 
@@ -34,6 +34,6 @@ def educational_occupational_programs_converter(**kwargs):
     educational_occupational_programs_converter = Converter(
         data_keywords_mapper,
         kwarg_to_schema_key_mapper,
-        required_keywords)
+        additional_required_keywords)
 
     return educational_occupational_programs_converter.trigger_conversion(kwargs)

--- a/converter/education/educational_occupational_programs_converter.py
+++ b/converter/education/educational_occupational_programs_converter.py
@@ -15,7 +15,7 @@ required_keywords = [
     "provider_name", 
     "provider_url", 
     "provider_telephone", 
-    "provider_contact_type",
+    "provider_telephone_contact_type",
     "time_to_complete", 
 ]
 

--- a/converter/education/educational_occupational_programs_converter.py
+++ b/converter/education/educational_occupational_programs_converter.py
@@ -15,7 +15,6 @@ required_keywords = [
     "provider_name", 
     "provider_url", 
     "provider_telephone", 
-    "provider_telephone_contact_type",
     "time_to_complete", 
 ]
 

--- a/converter/education/educational_occupational_programs_converter.py
+++ b/converter/education/educational_occupational_programs_converter.py
@@ -4,8 +4,12 @@ from converter.helper import (add_header, add_offers_data,
                               add_salary_upon_completion_data,
                               add_training_salary_data, add_identifier_data)
 
-# A list of keywords required in particular for EducationalOccupationPrograms.
-additional_required_keywords = [
+# A list of keywords required for EducationalOccupationPrograms.
+required_keywords = [
+    "provider_address",
+    "program_name",
+    "program_description",
+    "program_url",
     "application_deadline",
     "offers_price", 
     "provider_name", 
@@ -34,6 +38,6 @@ def educational_occupational_programs_converter(**kwargs):
     educational_occupational_programs_converter = Converter(
         data_keywords_mapper,
         kwarg_to_schema_key_mapper,
-        additional_required_keywords)
+        required_keywords)
 
     return educational_occupational_programs_converter.trigger_conversion(kwargs)

--- a/converter/education/educational_occupational_programs_converter.py
+++ b/converter/education/educational_occupational_programs_converter.py
@@ -15,6 +15,7 @@ required_keywords = [
     "provider_name", 
     "provider_url", 
     "provider_telephone", 
+    "provider_contact_type",
     "time_to_complete", 
 ]
 

--- a/converter/helper.py
+++ b/converter/helper.py
@@ -167,7 +167,7 @@ def add_salary_upon_completion_data(output, price: str):
 def add_identifier_data(output, cip=None, program_id=None):
     identifier_data = []
 
-    if not (cip and program_id):
+    if not cip and not program_id:
         raise ValueError('Missing kwargs! "identifier_cip" AND/OR "identifier_program_id" must have values.')
 
     if cip:

--- a/converter/helper.py
+++ b/converter/helper.py
@@ -66,10 +66,10 @@ def add_provider_data(json_ld: dict, kwargs: dict) -> dict:
     if 'provider_url' in kwargs:
         json_ld['provider']["url"] = kwargs['provider_url']
 
-    if 'provider_telephone' in kwargs and 'provider_telephone_contact_type' in kwargs:
+    if 'provider_telephone' in kwargs:
         json_ld['provider']['contactPoint'] = {
             "@type": "ContactPoint",
-            "contactType": kwargs['provider_telephone_contact_type'],
+            "contactType": "Admissions",
             "telephone": kwargs['provider_telephone']
         }
 

--- a/converter/helper.py
+++ b/converter/helper.py
@@ -69,6 +69,7 @@ def add_provider_data(json_ld: dict, kwargs: dict) -> dict:
     if 'provider_telephone' in kwargs:
         json_ld['provider']['contactPoint'] = {
             "@type": "ContactPoint",
+            "contactType": kwargs['provider_telephone_contact_type'],
             "telephone": kwargs['provider_telephone']
         }
 

--- a/converter/helper.py
+++ b/converter/helper.py
@@ -167,6 +167,9 @@ def add_salary_upon_completion_data(output, price: str):
 def add_identifier_data(output, cip=None, program_id=None):
     identifier_data = []
 
+    if not (cip and program_id):
+        raise ValueError('Missing kwargs! "identifier_cip" AND/OR "identifier_program_id" must have values.')
+
     if cip:
         identifier_data.append({
             "@type": "PropertyValue",

--- a/converter/helper.py
+++ b/converter/helper.py
@@ -66,7 +66,7 @@ def add_provider_data(json_ld: dict, kwargs: dict) -> dict:
     if 'provider_url' in kwargs:
         json_ld['provider']["url"] = kwargs['provider_url']
 
-    if 'provider_telephone' in kwargs:
+    if 'provider_telephone' in kwargs and 'provider_telephone_contact_type' in kwargs:
         json_ld['provider']['contactPoint'] = {
             "@type": "ContactPoint",
             "contactType": kwargs['provider_telephone_contact_type'],

--- a/converter/work/work_based_programs_converter.py
+++ b/converter/work/work_based_programs_converter.py
@@ -21,15 +21,9 @@ data_keywords_mapper = {
     ]
 }
 
-# A list of keywords that MUST be included in the source data, i.e., the data passed in a kwargs.
-required_keywords = [
-    "program_description"
-]
-
 def work_based_programs_converter(**kwargs):
     work_based_programs_converter = Converter(
         data_keywords_mapper,
-        kwarg_to_schema_key_mapper,
-        required_keywords)
+        kwarg_to_schema_key_mapper)
 
     return work_based_programs_converter.trigger_conversion(kwargs)

--- a/converter/work/work_based_programs_converter.py
+++ b/converter/work/work_based_programs_converter.py
@@ -4,6 +4,14 @@ from converter.helper import (add_header, add_offers_data,
                               add_salary_upon_completion_data,
                               add_training_salary_data)
 
+# A list of keywords required for WorkBasedPrograms.
+required_keywords = [
+    "provider_address",
+    "program_name",
+    "program_description",
+    "program_url"
+]
+
 kwarg_to_schema_key_mapper = {
     "program_description": "description",
     "program_name": "name",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,7 @@ def educational_input_kwargs(program_provider_address_data, offers, training_sal
     '''
     return {
         "application_deadline": "2020-04-01",
+        "program_description": "A description of a Goodwill program",
         "program_name": "Goodwill Program",
         "offers_price": 2000,
         "program_url": "goodwill.org",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,8 +103,8 @@ def educational_input_kwargs(program_provider_address_data, offers, training_sal
         "provider_telephone": "333-343-4444",
         "provider_address": program_provider_address_data,
         "time_to_complete": "P6M",
-        "identifier_cip": "51.3902", # optional, but identifier blob is not
-        "identifier_program_id": "5688", # optional, but identifier blob is not
+        "identifier_cip": "51.3902", # Must include CIP or Program Identifier
+        "identifier_program_id": "5688",
         "application_start_date": "2020-01-01",
         "program_prerequisites": {
             "credential_category": "HighSchool",
@@ -114,7 +114,7 @@ def educational_input_kwargs(program_provider_address_data, offers, training_sal
         },
         "end_date": "2020-12-01",
         "occupational_credential_awarded": "Associate Degree",
-        "maximum_enrollment": "50", # It looks like Goodwill is not actually collecting this....
+        "maximum_enrollment": "50",
         "offers_price": offers['priceSpecification']['price'],
         "start_date": "2020-04-01",
         "time_of_day": "Evening",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ def work_based_input_kwargs(program_provider_address_data, offers, training_sala
         "provider_name": "Goodwill of Tucson",
         "provider_url": "goodwill.org",
         "provider_telephone": "333-343-4444",
+        "provider_telephone_contact_type": "Goodwill Office",
         "provider_address": program_provider_address_data,
         "program_prerequisites": {
             "credential_category": "HighSchool",
@@ -101,6 +102,7 @@ def educational_input_kwargs(program_provider_address_data, offers, training_sal
         "provider_name": "Goodwill of Tucson",
         "provider_url": "goodwill.org",
         "provider_telephone": "333-343-4444",
+        "provider_telephone_contact_type": "Goodwill Office",
         "provider_address": program_provider_address_data,
         "time_to_complete": "P6M",
         "identifier_cip": "51.3902", # Must include CIP or Program Identifier

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,6 @@ def work_based_input_kwargs(program_provider_address_data, offers, training_sala
         "provider_name": "Goodwill of Tucson",
         "provider_url": "goodwill.org",
         "provider_telephone": "333-343-4444",
-        "provider_telephone_contact_type": "Goodwill Office",
         "provider_address": program_provider_address_data,
         "program_prerequisites": {
             "credential_category": "HighSchool",
@@ -102,7 +101,6 @@ def educational_input_kwargs(program_provider_address_data, offers, training_sal
         "provider_name": "Goodwill of Tucson",
         "provider_url": "goodwill.org",
         "provider_telephone": "333-343-4444",
-        "provider_telephone_contact_type": "Goodwill Office",
         "provider_address": program_provider_address_data,
         "time_to_complete": "P6M",
         "identifier_cip": "51.3902", # Must include CIP or Program Identifier

--- a/tests/education/test_main_education.py
+++ b/tests/education/test_main_education.py
@@ -12,8 +12,9 @@ def test_educational_occupational_converter_all(educational_input_kwargs, offers
     expected_output = {
         "@context": "http://schema.org/",
         "@type": "EducationalOccupationalProgram",
-        "applicationDeadline": educational_input_kwargs['application_deadline'],
-        "name": educational_input_kwargs['program_name'],
+        "description": educational_input_kwargs["program_description"],
+        "applicationDeadline": educational_input_kwargs["application_deadline"],
+        "name": educational_input_kwargs["program_name"],
         "identifier": [
             {
                 "@type": "PropertyValue",
@@ -30,26 +31,26 @@ def test_educational_occupational_converter_all(educational_input_kwargs, offers
         "url": educational_input_kwargs["program_url"],
         "provider": {
             "@type": "EducationalOrganization",
-            "name": educational_input_kwargs['provider_name'],
+            "name": educational_input_kwargs["provider_name"],
             "address": [ 
                 {
                     "@type": "PostalAddress", 
-                    "streetAddress": educational_input_kwargs['provider_address'][0]['street_address'],
-                    "addressLocality": educational_input_kwargs['provider_address'][0]['address_locality'],
-                    "addressRegion": educational_input_kwargs['provider_address'][0]['address_region'],
-                    "postalCode": educational_input_kwargs['provider_address'][0]['postal_code']
+                    "streetAddress": educational_input_kwargs["provider_address"][0]["street_address"],
+                    "addressLocality": educational_input_kwargs["provider_address"][0]["address_locality"],
+                    "addressRegion": educational_input_kwargs["provider_address"][0]["address_region"],
+                    "postalCode": educational_input_kwargs["provider_address"][0]["postal_code"]
                 }
             ],
-            "url": educational_input_kwargs['provider_url'],
+            "url": educational_input_kwargs["provider_url"],
             "contactPoint": {
                 "@type": "ContactPoint",
-                "telephone": educational_input_kwargs['provider_telephone']
+                "telephone": educational_input_kwargs["provider_telephone"]
             }
         },
-        "timeToComplete": educational_input_kwargs['time_to_complete'],
-        "applicationStartDate": educational_input_kwargs['application_start_date'],
-        "endDate": educational_input_kwargs['end_date'],
-        "startDate": educational_input_kwargs['start_date'],
+        "timeToComplete": educational_input_kwargs["time_to_complete"],
+        "applicationStartDate": educational_input_kwargs["application_start_date"],
+        "endDate": educational_input_kwargs["end_date"],
+        "startDate": educational_input_kwargs["start_date"],
         "occupationalCredentialAwarded": educational_input_kwargs["occupational_credential_awarded"],
         "maximumEnrollment": educational_input_kwargs["maximum_enrollment"],
         "programPrerequisites": [
@@ -79,9 +80,10 @@ def test_educational_occupational_converter_all(educational_input_kwargs, offers
     expect(json_output).to(equal(json_expected_output))
 
 
-def test_educational_occupational_converter_recommended(educational_input_kwargs, offers):
+def test_educational_occupational_converter_required(educational_input_kwargs, offers):
     required_kwargs = {
         "application_deadline": educational_input_kwargs["application_deadline"],
+        "program_description": educational_input_kwargs["program_description"],
         "program_name": educational_input_kwargs["program_name"],
         "offers_price": educational_input_kwargs["offers_price"],
         "program_url": educational_input_kwargs["program_url"],
@@ -95,30 +97,31 @@ def test_educational_occupational_converter_recommended(educational_input_kwargs
     expected_output = {
         "@context": "http://schema.org/",
         "@type": "EducationalOccupationalProgram",
-        "applicationDeadline": educational_input_kwargs['application_deadline'],
-        "name": educational_input_kwargs['program_name'],
+        "applicationDeadline": educational_input_kwargs["application_deadline"],
+        "name": educational_input_kwargs["program_name"],
+        "description": educational_input_kwargs["program_description"],
         "identifier": [], # Can we ask Goodwill to provide one or the other value? They cannot provide both. How do we validate for one or more fields? 
         "offers": offers,
         "url": educational_input_kwargs["program_url"],
         "provider": {
             "@type": "EducationalOrganization",
-            "name": educational_input_kwargs['provider_name'],
+            "name": educational_input_kwargs["provider_name"],
             "address": [ 
                 {
                     "@type": "PostalAddress", 
-                    "streetAddress": educational_input_kwargs['provider_address'][0]['street_address'],
-                    "addressLocality": educational_input_kwargs['provider_address'][0]['address_locality'],
-                    "addressRegion": educational_input_kwargs['provider_address'][0]['address_region'],
-                    "postalCode": educational_input_kwargs['provider_address'][0]['postal_code']
+                    "streetAddress": educational_input_kwargs["provider_address"][0]["street_address"],
+                    "addressLocality": educational_input_kwargs["provider_address"][0]["address_locality"],
+                    "addressRegion": educational_input_kwargs["provider_address"][0]["address_region"],
+                    "postalCode": educational_input_kwargs["provider_address"][0]["postal_code"]
                 }
             ],
-            "url": educational_input_kwargs['provider_url'],
+            "url": educational_input_kwargs["provider_url"],
             "contactPoint": {
                 "@type": "ContactPoint",
-                "telephone": educational_input_kwargs['provider_telephone']
+                "telephone": educational_input_kwargs["provider_telephone"]
             }
         },
-        "timeToComplete": educational_input_kwargs['time_to_complete']
+        "timeToComplete": educational_input_kwargs["time_to_complete"]
     }
 
     output = educational_occupational_programs_converter(**required_kwargs)

--- a/tests/education/test_main_education.py
+++ b/tests/education/test_main_education.py
@@ -44,7 +44,7 @@ def test_educational_occupational_converter_all(educational_input_kwargs, offers
             "url": educational_input_kwargs["provider_url"],
             "contactPoint": {
                 "@type": "ContactPoint",
-                "contactType": educational_input_kwargs["provider_telephone_contact_type"],
+                "contactType": "Admissions",
                 "telephone": educational_input_kwargs["provider_telephone"]
             }
         },
@@ -91,7 +91,6 @@ def test_educational_occupational_converter_required(educational_input_kwargs, o
         "provider_name": educational_input_kwargs["provider_name"],
         "provider_url": educational_input_kwargs["provider_url"],
         "provider_telephone": educational_input_kwargs["provider_telephone"],
-        "provider_telephone_contact_type": educational_input_kwargs["provider_telephone_contact_type"],
         "provider_address": educational_input_kwargs["provider_address"],
         "time_to_complete": educational_input_kwargs["time_to_complete"],
         "identifier_program_id": educational_input_kwargs["identifier_program_id"]
@@ -127,7 +126,7 @@ def test_educational_occupational_converter_required(educational_input_kwargs, o
             "url": educational_input_kwargs["provider_url"],
             "contactPoint": {
                 "@type": "ContactPoint",
-                "contactType": educational_input_kwargs["provider_telephone_contact_type"],
+                "contactType": "Admissions",
                 "telephone": educational_input_kwargs["provider_telephone"]
             }
         },

--- a/tests/education/test_main_education.py
+++ b/tests/education/test_main_education.py
@@ -44,6 +44,7 @@ def test_educational_occupational_converter_all(educational_input_kwargs, offers
             "url": educational_input_kwargs["provider_url"],
             "contactPoint": {
                 "@type": "ContactPoint",
+                "contactType": educational_input_kwargs["provider_telephone_contact_type"],
                 "telephone": educational_input_kwargs["provider_telephone"]
             }
         },
@@ -90,6 +91,7 @@ def test_educational_occupational_converter_required(educational_input_kwargs, o
         "provider_name": educational_input_kwargs["provider_name"],
         "provider_url": educational_input_kwargs["provider_url"],
         "provider_telephone": educational_input_kwargs["provider_telephone"],
+        "provider_telephone_contact_type": educational_input_kwargs["provider_telephone_contact_type"],
         "provider_address": educational_input_kwargs["provider_address"],
         "time_to_complete": educational_input_kwargs["time_to_complete"],
         "identifier_program_id": educational_input_kwargs["identifier_program_id"]
@@ -125,6 +127,7 @@ def test_educational_occupational_converter_required(educational_input_kwargs, o
             "url": educational_input_kwargs["provider_url"],
             "contactPoint": {
                 "@type": "ContactPoint",
+                "contactType": educational_input_kwargs["provider_telephone_contact_type"],
                 "telephone": educational_input_kwargs["provider_telephone"]
             }
         },

--- a/tests/education/test_main_education.py
+++ b/tests/education/test_main_education.py
@@ -92,6 +92,7 @@ def test_educational_occupational_converter_required(educational_input_kwargs, o
         "provider_telephone": educational_input_kwargs["provider_telephone"],
         "provider_address": educational_input_kwargs["provider_address"],
         "time_to_complete": educational_input_kwargs["time_to_complete"],
+        "identifier_program_id": educational_input_kwargs["identifier_program_id"]
     }
     
     expected_output = {
@@ -100,7 +101,13 @@ def test_educational_occupational_converter_required(educational_input_kwargs, o
         "applicationDeadline": educational_input_kwargs["application_deadline"],
         "name": educational_input_kwargs["program_name"],
         "description": educational_input_kwargs["program_description"],
-        "identifier": [], # Can we ask Goodwill to provide one or the other value? They cannot provide both. How do we validate for one or more fields? 
+        "identifier": [
+            {
+                "@type": "PropertyValue",
+                "propertyID": "ProgramID",
+                "value": educational_input_kwargs["identifier_program_id"]
+            }
+        ],
         "offers": offers,
         "url": educational_input_kwargs["program_url"],
         "provider": {

--- a/tests/helper/test_add_identifier.py
+++ b/tests/helper/test_add_identifier.py
@@ -33,20 +33,7 @@ def test_add_identifier_data(educational_input_kwargs):
     expect(json_output).to(equal(json_expected_output))
 
 
-def test_add_identifier_data_no_values():
-    output = add_identifier_data({})
-
-    expected_output = {
-        "identifier": []
-    }
-
-    json_expected_output = json.dumps(expected_output, sort_keys=True)
-    json_output = json.dumps(output, sort_keys=True)
-
-    expect(json_output).to(equal(json_expected_output))
-
-
-def test_add_identifier_data_one_value(educational_input_kwargs):
+def test_add_identifier_data_cip_value(educational_input_kwargs):
     cip = educational_input_kwargs['identifier_cip']
 
     output = add_identifier_data({}, cip=cip)
@@ -65,3 +52,32 @@ def test_add_identifier_data_one_value(educational_input_kwargs):
     json_output = json.dumps(output, sort_keys=True)
 
     expect(json_output).to(equal(json_expected_output))
+
+
+def test_add_identifier_data_id_value(educational_input_kwargs):
+    program_id = educational_input_kwargs['identifier_program_id']
+
+    output = add_identifier_data({}, program_id=program_id)
+
+    expected_output = {
+        "identifier": [
+            {
+                "@type": "PropertyValue",
+                "propertyID": "ProgramID",
+                "value": program_id
+            }
+        ]
+    }
+
+    json_expected_output = json.dumps(expected_output, sort_keys=True)
+    json_output = json.dumps(output, sort_keys=True)
+
+    expect(json_output).to(equal(json_expected_output))
+
+
+def test_add_identifier_data_no_values():
+    with pytest.raises(Exception) as execinfo: 
+        add_identifier_data({})
+
+    expected_error = 'Missing kwargs! "identifier_cip" AND/OR "identifier_program_id" must have values.'
+    expect(str(execinfo.value)).to(equal(expected_error))

--- a/tests/helper/test_add_provider.py
+++ b/tests/helper/test_add_provider.py
@@ -10,7 +10,6 @@ def test_add_provider_data_all_fields(work_based_input_kwargs, program_provider_
         "provider_name": work_based_input_kwargs["provider_name"],
         "provider_url": work_based_input_kwargs["provider_url"],
         "provider_telephone": work_based_input_kwargs["provider_telephone"],
-        "provider_telephone_contact_type": work_based_input_kwargs["provider_telephone_contact_type"],
         "provider_address": program_provider_address_data
     }
 
@@ -30,7 +29,7 @@ def test_add_provider_data_all_fields(work_based_input_kwargs, program_provider_
             "url": work_based_input_kwargs["provider_url"],
             "contactPoint": {
                 "@type": "ContactPoint",
-                "contactType": work_based_input_kwargs["provider_telephone_contact_type"],
+                "contactType": "Admissions",
                 "telephone": work_based_input_kwargs["provider_telephone"]
             }
         },

--- a/tests/helper/test_add_provider.py
+++ b/tests/helper/test_add_provider.py
@@ -7,29 +7,31 @@ from tests.conftest import pprint_diff
 
 def test_add_provider_data_all_fields(work_based_input_kwargs, program_provider_address_data):
     kwargs = {
-        "provider_name": work_based_input_kwargs['provider_name'],
-        "provider_url": work_based_input_kwargs['provider_url'],
-        "provider_telephone": work_based_input_kwargs['provider_telephone'],
+        "provider_name": work_based_input_kwargs["provider_name"],
+        "provider_url": work_based_input_kwargs["provider_url"],
+        "provider_telephone": work_based_input_kwargs["provider_telephone"],
+        "provider_telephone_contact_type": work_based_input_kwargs["provider_telephone_contact_type"],
         "provider_address": program_provider_address_data
     }
 
     expected_output = {
         "provider": {
             "@type": "EducationalOrganization",
-            "name": work_based_input_kwargs['provider_name'],
+            "name": work_based_input_kwargs["provider_name"],
             "address": [ 
                 {
                     "@type": "PostalAddress", 
-                    "streetAddress": work_based_input_kwargs['provider_address'][0]['street_address'],
-                    "addressLocality": work_based_input_kwargs['provider_address'][0]['address_locality'],
-                    "addressRegion": work_based_input_kwargs['provider_address'][0]['address_region'],
-                    "postalCode": work_based_input_kwargs['provider_address'][0]['postal_code']
+                    "streetAddress": work_based_input_kwargs["provider_address"][0]["street_address"],
+                    "addressLocality": work_based_input_kwargs["provider_address"][0]["address_locality"],
+                    "addressRegion": work_based_input_kwargs["provider_address"][0]["address_region"],
+                    "postalCode": work_based_input_kwargs["provider_address"][0]["postal_code"]
                 }
             ],
-            "url": work_based_input_kwargs['provider_url'],
+            "url": work_based_input_kwargs["provider_url"],
             "contactPoint": {
                 "@type": "ContactPoint",
-                "telephone": work_based_input_kwargs['provider_telephone']
+                "contactType": work_based_input_kwargs["provider_telephone_contact_type"],
+                "telephone": work_based_input_kwargs["provider_telephone"]
             }
         },
     }
@@ -53,10 +55,10 @@ def test_add_provider_data_only_required_fields(work_based_input_kwargs, program
             "address": [ 
                 {
                     "@type": "PostalAddress", 
-                    "streetAddress": work_based_input_kwargs['provider_address'][0]['street_address'],
-                    "addressLocality": work_based_input_kwargs['provider_address'][0]['address_locality'],
-                    "addressRegion": work_based_input_kwargs['provider_address'][0]['address_region'],
-                    "postalCode": work_based_input_kwargs['provider_address'][0]['postal_code']
+                    "streetAddress": work_based_input_kwargs["provider_address"][0]["street_address"],
+                    "addressLocality": work_based_input_kwargs["provider_address"][0]["address_locality"],
+                    "addressRegion": work_based_input_kwargs["provider_address"][0]["address_region"],
+                    "postalCode": work_based_input_kwargs["provider_address"][0]["postal_code"]
                 }
             ],
         },

--- a/tests/helper/test_other_helper_functions.py
+++ b/tests/helper/test_other_helper_functions.py
@@ -40,10 +40,10 @@ def test_add_basic_keywords(work_based_input_kwargs):
 
 def test_add_data_keywords(work_based_input_kwargs, training_salary, salary_upon_completion):
     data_keywords_mapper = {
-        "program_prerequisites": lambda output, kwargs: add_prerequisites_data(output, kwargs['program_prerequisites']),
-        "offers_price": lambda output, kwargs: add_offers_data(output, kwargs['offers_price']),
-        "training_salary": lambda output, kwargs: add_training_salary_data(output, kwargs['training_salary']),
-        "salary_upon_completion": lambda output, kwargs: add_salary_upon_completion_data(output, kwargs['salary_upon_completion']),
+        "program_prerequisites": lambda output, kwargs: add_prerequisites_data(output, kwargs["program_prerequisites"]),
+        "offers_price": lambda output, kwargs: add_offers_data(output, kwargs["offers_price"]),
+        "training_salary": lambda output, kwargs: add_training_salary_data(output, kwargs["training_salary"]),
+        "salary_upon_completion": lambda output, kwargs: add_salary_upon_completion_data(output, kwargs["salary_upon_completion"]),
         "all": [
             lambda output, kwargs: add_header(output, "WorkBasedProgram"),
             lambda output, kwargs: add_provider_data(output, kwargs)
@@ -95,6 +95,7 @@ def test_add_data_keywords(work_based_input_kwargs, training_salary, salary_upon
             "url": work_based_input_kwargs['provider_url'],
             "contactPoint": {
                 "@type": "ContactPoint",
+                "contactType": work_based_input_kwargs["provider_telephone_contact_type"],
                 "telephone": work_based_input_kwargs['provider_telephone']
             }
         },

--- a/tests/helper/test_other_helper_functions.py
+++ b/tests/helper/test_other_helper_functions.py
@@ -95,7 +95,7 @@ def test_add_data_keywords(work_based_input_kwargs, training_salary, salary_upon
             "url": work_based_input_kwargs['provider_url'],
             "contactPoint": {
                 "@type": "ContactPoint",
-                "contactType": work_based_input_kwargs["provider_telephone_contact_type"],
+                "contactType": "Admissions",
                 "telephone": work_based_input_kwargs['provider_telephone']
             }
         },

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -11,7 +11,7 @@ def test_check_for_required(input_kwargs,required_keywords, should_error):
     converter = Converter(
         data_keywords_mapper={"all": []},
         kwarg_to_schema_key_mapper={},
-        required_keywords=required_keywords
+        additional_required_keywords=required_keywords
     )
 
     if should_error:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -25,7 +25,7 @@ def test_check_for_required(input_kwargs, required_keywords, should_error):
             output = converter.trigger_conversion(input_kwargs)
 
         assert "Missing kwargs! Please include values for the following fields" in str(exceptionMsg.value)
-        assert ",".join(required_keywords) in str(exceptionMsg.value)
+        assert ", ".join(required_keywords) in str(exceptionMsg.value)
     else:
         output = converter.trigger_conversion(input_kwargs)
         assert output == {}

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -6,6 +6,7 @@ from converter.converter import Converter
     ({"a_recommended_keyword": "value"}, ["a_required_keyword"], True),
     ({"a_recommended_keyword": "value"}, ["a_required_keyword, another_required_keyword"], True),
     ({"a_required_keyword_with_no_value": ""}, ["a_required_keyword_with_no_value"], True),
+    ({"a_required_keyword_with_no_value": None}, ["a_required_keyword_with_no_value"], True),
     ({"a_required_keyword": "value"}, ["a_required_keyword"], False)
 ])
 def test_check_for_required(input_kwargs, required_keywords, should_error):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2,25 +2,38 @@ import pytest
 
 from converter.converter import Converter
 
-@pytest.mark.parametrize("input_kwargs,required_keywords,should_error", [
+@pytest.mark.parametrize("input_kwargs,additional_required_keywords,should_error", [
     ({"a_recommended_keyword": "value"}, ["a_required_keyword"], True),
     ({"a_recommended_keyword": "value"}, ["a_required_keyword, another_required_keyword"], True),
+    ({"a_required_keyword_with_no_value": ""}, ["a_required_keyword_with_no_value"], True),
     ({"a_required_keyword": "value"}, ["a_required_keyword"], False)
 ])
-def test_check_for_required(input_kwargs,required_keywords, should_error):
+def test_check_for_required(work_based_input_kwargs, input_kwargs, additional_required_keywords, should_error):
+    required_input_kwargs = {
+        "provider_address": work_based_input_kwargs["provider_address"],
+        "program_name": work_based_input_kwargs["program_name"],
+        "program_description": work_based_input_kwargs["program_description"],
+        "program_url": work_based_input_kwargs["program_url"]
+    }
+
+    input_kwargs.update(required_input_kwargs)
+
     converter = Converter(
         data_keywords_mapper={"all": []},
-        kwarg_to_schema_key_mapper={},
-        additional_required_keywords=required_keywords
+        kwarg_to_schema_key_mapper={
+            "program_description": "description",
+            "program_name": "name",
+            "program_url": "url"
+        },
+        additional_required_keywords=additional_required_keywords
     )
 
     if should_error:
-        with pytest.raises(RuntimeError) as exceptionMsg:
+        with pytest.raises(ValueError) as exceptionMsg:
             output = converter.trigger_conversion(input_kwargs)
 
-        assert "One or more required properties needs to be included in the kwargs" in str(exceptionMsg.value)
-        assert ",".join(required_keywords) in str(exceptionMsg.value)
+        assert "Missing kwargs! Please include values for the following fields" in str(exceptionMsg.value)
+        assert ",".join(additional_required_keywords) in str(exceptionMsg.value)
     else:
         output = converter.trigger_conversion(input_kwargs)
-
-        assert output == {}
+        assert output == {'name': 'Goodwill Program', 'description': 'A description of a Goodwill program', 'url': 'goodwill.org'}

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2,22 +2,13 @@ import pytest
 
 from converter.converter import Converter
 
-@pytest.mark.parametrize("input_kwargs,additional_required_keywords,should_error", [
+@pytest.mark.parametrize("input_kwargs,required_keywords,should_error", [
     ({"a_recommended_keyword": "value"}, ["a_required_keyword"], True),
     ({"a_recommended_keyword": "value"}, ["a_required_keyword, another_required_keyword"], True),
     ({"a_required_keyword_with_no_value": ""}, ["a_required_keyword_with_no_value"], True),
     ({"a_required_keyword": "value"}, ["a_required_keyword"], False)
 ])
-def test_check_for_required(work_based_input_kwargs, input_kwargs, additional_required_keywords, should_error):
-    required_input_kwargs = {
-        "provider_address": work_based_input_kwargs["provider_address"],
-        "program_name": work_based_input_kwargs["program_name"],
-        "program_description": work_based_input_kwargs["program_description"],
-        "program_url": work_based_input_kwargs["program_url"]
-    }
-
-    input_kwargs.update(required_input_kwargs)
-
+def test_check_for_required(input_kwargs, required_keywords, should_error):
     converter = Converter(
         data_keywords_mapper={"all": []},
         kwarg_to_schema_key_mapper={
@@ -25,7 +16,7 @@ def test_check_for_required(work_based_input_kwargs, input_kwargs, additional_re
             "program_name": "name",
             "program_url": "url"
         },
-        additional_required_keywords=additional_required_keywords
+        required_keywords=required_keywords
     )
 
     if should_error:
@@ -33,7 +24,22 @@ def test_check_for_required(work_based_input_kwargs, input_kwargs, additional_re
             output = converter.trigger_conversion(input_kwargs)
 
         assert "Missing kwargs! Please include values for the following fields" in str(exceptionMsg.value)
-        assert ",".join(additional_required_keywords) in str(exceptionMsg.value)
+        assert ",".join(required_keywords) in str(exceptionMsg.value)
     else:
         output = converter.trigger_conversion(input_kwargs)
-        assert output == {'name': 'Goodwill Program', 'description': 'A description of a Goodwill program', 'url': 'goodwill.org'}
+        assert output == {}
+
+
+@pytest.mark.parametrize("required_keywords,initialized_required_keywords", [
+    ("provider_address", ["provider_address"]),
+    ("provider_address,program_name,program_url", ["provider_address", "program_name", "program_url"]),
+    ("provider_address, program_name", ["provider_address", "program_name"])
+])
+def test_required_keywords_init(required_keywords, initialized_required_keywords):
+    converter = Converter(
+        data_keywords_mapper={"all": []},
+        kwarg_to_schema_key_mapper={},
+        required_keywords=required_keywords
+    )
+
+    assert converter.required_keywords == initialized_required_keywords

--- a/tests/work/test_main_work.py
+++ b/tests/work/test_main_work.py
@@ -29,6 +29,7 @@ def test_work_based_programs_converter_all(work_based_input_kwargs, offers, trai
             "url": work_based_input_kwargs['provider_url'],
             "contactPoint": {
                 "@type": "ContactPoint",
+                "contactType": work_based_input_kwargs['provider_telephone_contact_type'],
                 "telephone": work_based_input_kwargs['provider_telephone']
             }
         },
@@ -74,6 +75,7 @@ def test_work_based_programs_converter_required(work_based_input_kwargs):
         "provider_name": work_based_input_kwargs['provider_name'],
         "provider_url": work_based_input_kwargs['provider_url'],
         "provider_telephone": work_based_input_kwargs['provider_telephone'],
+        "provider_telephone_contact_type": work_based_input_kwargs['provider_telephone_contact_type'],
         "provider_address": work_based_input_kwargs['provider_address']
     }
     output = work_based_programs_converter(**required_kwargs)
@@ -99,6 +101,7 @@ def test_work_based_programs_converter_required(work_based_input_kwargs):
             "url": work_based_input_kwargs['provider_url'],
             "contactPoint": {
                 "@type": "ContactPoint",
+                "contactType": work_based_input_kwargs['provider_telephone_contact_type'],
                 "telephone": work_based_input_kwargs['provider_telephone']
             }
         }

--- a/tests/work/test_main_work.py
+++ b/tests/work/test_main_work.py
@@ -29,7 +29,7 @@ def test_work_based_programs_converter_all(work_based_input_kwargs, offers, trai
             "url": work_based_input_kwargs['provider_url'],
             "contactPoint": {
                 "@type": "ContactPoint",
-                "contactType": work_based_input_kwargs['provider_telephone_contact_type'],
+                "contactType": "Admissions",
                 "telephone": work_based_input_kwargs['provider_telephone']
             }
         },
@@ -75,7 +75,6 @@ def test_work_based_programs_converter_required(work_based_input_kwargs):
         "provider_name": work_based_input_kwargs['provider_name'],
         "provider_url": work_based_input_kwargs['provider_url'],
         "provider_telephone": work_based_input_kwargs['provider_telephone'],
-        "provider_telephone_contact_type": work_based_input_kwargs['provider_telephone_contact_type'],
         "provider_address": work_based_input_kwargs['provider_address']
     }
     output = work_based_programs_converter(**required_kwargs)
@@ -101,7 +100,7 @@ def test_work_based_programs_converter_required(work_based_input_kwargs):
             "url": work_based_input_kwargs['provider_url'],
             "contactPoint": {
                 "@type": "ContactPoint",
-                "contactType": work_based_input_kwargs['provider_telephone_contact_type'],
+                "contactType": "Admissions",
                 "telephone": work_based_input_kwargs['provider_telephone']
             }
         }


### PR DESCRIPTION
# Description

This PR handles required fields in the Pathways/Schems.org definitions, which previously had not been handled.

Closes https://app.clubhouse.io/brighthive/story/730/handle-all-required-fields

# Checklists

### Basic

- [x] Did you write tests for the code in this PR?
- [x] Did you document your changes in the README and/or in docstrings (as needed)?

# Notes for the Reviewer

@loganripplinger - I'd appreciate a review of the changes in the `Converter` class and the helper function `add_identifier_data`. Specifically:

* `_check_for_required` – this function previously checked for the existence of keywords, but it did not check if those keywords had values. I added a check for empty strings, too. Why? Apparently, if a required field has an empty string as the value, then Google pathways raises an error. https://github.com/brighthive/google-pathways-converter/pull/12/files#diff-b9ee80b83caa7233f65166716c9cc6eeR18
* `add_identifier_data` – similar to above, Google pathways raises an error if the identifier field is missing a CIP and/or program ID. I tried to add this check to `_check_for_required`, but it go messy, since the kwargs can include either/or.