### PR TITLE
fix: Add strict property requirements for programPrerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ You need to consider the following fields for the educational-occupational conve
 | identifier_cip  AND/OR identifier_program_id | String
 | **RECOMMENDED FIELDS**                
 | application_start_date             | String
-| program_prerequisites              | A dict with any number of keywords, e.g., credential_category, eligible_groups, max_income_eligibility, other_program_prerequisites, etc.
 | start_date                         | String that represents a date in ISO-8601 format
 | end_date                           | String that represents a date in ISO-8601 format
 | occupational_credential_awarded    | String
 | maximum_enrollment                 | String
 | offers_price                       | Integer
 | time_of_day                        | String 
+| program_prerequisites              | A dict with up to two specified keywords: "competency_required" (knowledge, skill, ability or personal attribute that a program participant must be able to demonstrate) and/or "credential_category" (a type of credential that a program participant must have)
 
 ### Converter kwargs: Work Based Programs
 You need to consider the following fields for the work-based converter: `work_based_programs_converter`.
@@ -67,13 +67,13 @@ You need to consider the following fields for the work-based converter: `work_ba
 | provider_url                       | String
 | provider_telephone                 | String
 | identifier_program_id              | String
-| program_prerequisites              | A dict with any number of keywords, e.g., credential_category, eligible_groups, max_income_eligibility, other_program_prerequisites, etc.
 | start_date                         | String that represents a date in ISO-8601 format
 | end_date                           | String that represents a date in ISO-8601 format
 | occupational_credential_awarded    | String
 | maximum_enrollment                 | String
 | offers_price                       | Integer
 | time_of_day                        | String 
+| program_prerequisites              | A dict with up to two specified keywords: "competency_required" (knowledge, skill, ability or personal attribute that a program participant must be able to demonstrate) and/or "credential_category" (a type of credential that a program participant must have)
 
 ### Example
 
@@ -103,11 +103,9 @@ programs_input = {
     'identifier_program_id': '5688', 
     'application_start_date': '2020-01-01', 
     'program_prerequisites': {
-        'credential_category': 'HighSchool', 
-        'eligible_groups': 'Youth', 
-        'max_income_eligibility': '20000', 
-        'other_program_prerequisites': 'other'
-    }, 
+        'credential_category': 'HighSchool',
+        'competency_required': 'Valid driver’s license'
+    },
     'end_date': '2020-12-01', 
     'occupational_credential_awarded': 'Food Handlers Certification', 
     'maximum_enrollment': '50', 
@@ -151,24 +149,11 @@ json.dumps(output, sort_keys=True)
             "priceCurrency": "USD"
         }
     }, 
-    "programPrerequisites": [
-        {
-            "@type": "EducationalOccupationalCredential", 
-            "credentialCategory": "HighSchool"
-        }, 
-        {
-            "@type": "Text", 
-            "eligibleGroups": "Youth"
-        },
-        {
-            "@type": "Text", 
-            "maxIncomeEligibility": "20000"
-        }, 
-        {
-            "@type": "Text", 
-            "otherProgramPrerequisites": "other"
-        }
-    ], 
+    "programPrerequisites": {
+        "@type": "EducationalOccupationalCredential",
+        "credentialCategory": "HighSchool",
+        "competencyRequired": "Valid driver’s license"
+    },
     "provider": {
         "@type": "EducationalOrganization", 
         "address": [

--- a/converter/education/educational_occupational_programs_converter.py
+++ b/converter/education/educational_occupational_programs_converter.py
@@ -25,7 +25,7 @@ kwarg_to_schema_key_mapper = {
 }
 
 data_keywords_mapper = {
-    "program_prerequisites": lambda output, kwargs: add_prerequisites_data(output, kwargs['program_prerequisites']),
+    "program_prerequisites": lambda output, kwargs: add_prerequisites_data(output, kwargs.get('program_prerequisites')),
     "offers_price": lambda output, kwargs: add_offers_data(output, kwargs['offers_price']),
     "all": [
         lambda output, kwargs: add_header(output, "EducationalOccupationalProgram"),

--- a/converter/helper.py
+++ b/converter/helper.py
@@ -98,28 +98,30 @@ def add_address_data(json_ld: dict, address: dict) -> dict:
     return json_ld
 
 
-def add_prerequisites_data(json_ld: dict, prerequisites: list) -> dict:
-    json_ld['programPrerequisites'] = []
-
-    for prereq_key, prereq_value in prerequisites.items():
-        json_ld = add_prerequisite(json_ld, prereq_key, prereq_value)
-
-    return json_ld
-
-
-def add_prerequisite(json_ld: dict, prereq_key: str, prereq_value: str) -> dict:
-    prereq_type = "Text"
-    if "credential_category" == prereq_key:
-        prereq_type = "EducationalOccupationalCredential"
-
-    camelcase_prereq = stringcase.camelcase(prereq_key)
-
-    prereq_node = {
-        "@type": prereq_type,
-        camelcase_prereq: prereq_value
+def add_prerequisites_data(json_ld: dict, prerequisites: dict) -> dict:
+    '''
+    `programPrerequisites` accepts an EducationalOccupationalCredential object as its value.
+    Currently, the BrightHive converter can handle two properties for the EducationalOccupationalCredential object:
+        - credentialCategory: the level of education required, e.g., HighSchool
+        - competencyRequired: knowledge, skill, ability, or personal attribute that must be demonstrated by a person or other entity.
+    '''
+    prereq_dict = {
+        "@type": "EducationalOccupationalCredential"
     }
+    try:
+        credential_category = prerequisites["credential_category"]
+        prereq_dict["credentialCategory"] = credential_category 
+    except (KeyError, TypeError):
+        pass
 
-    json_ld['programPrerequisites'].append(prereq_node)
+    try: 
+        competency_required = prerequisites["competency_required"]
+        prereq_dict["competencyRequired"] = competency_required
+    except (KeyError, TypeError):
+        pass
+    
+    if len(prereq_dict) > 1:
+        json_ld['programPrerequisites'] = prereq_dict
 
     return json_ld
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,9 +70,7 @@ def work_based_input_kwargs(program_provider_address_data, offers, training_sala
         "provider_address": program_provider_address_data,
         "program_prerequisites": {
             "credential_category": "HighSchool",
-            "eligible_groups": "Youth",
-            "max_income_eligibility": "20000",
-            "other_program_prerequisites": "other"
+            "competency_required": "Valid driver’s license"
         },
         "end_date": "2020-12-01",
         "start_date": "2020-04-01",
@@ -108,9 +106,7 @@ def educational_input_kwargs(program_provider_address_data, offers, training_sal
         "application_start_date": "2020-01-01",
         "program_prerequisites": {
             "credential_category": "HighSchool",
-            "eligible_groups": "Youth",
-            "max_income_eligibility": "20000",
-            "other_program_prerequisites": "other"
+            "competency_required": "Valid driver’s license"
         },
         "end_date": "2020-12-01",
         "occupational_credential_awarded": "Associate Degree",

--- a/tests/education/test_main_education.py
+++ b/tests/education/test_main_education.py
@@ -54,24 +54,11 @@ def test_educational_occupational_converter_all(educational_input_kwargs, offers
         "startDate": educational_input_kwargs["start_date"],
         "occupationalCredentialAwarded": educational_input_kwargs["occupational_credential_awarded"],
         "maximumEnrollment": educational_input_kwargs["maximum_enrollment"],
-        "programPrerequisites": [
-            {
-                "@type": "EducationalOccupationalCredential", 
-                "credentialCategory": educational_input_kwargs["program_prerequisites"]["credential_category"]
-            },
-            {
-                "@type": "Text",
-                "eligibleGroups": educational_input_kwargs["program_prerequisites"]["eligible_groups"]
-            },
-            {
-                "@type": "Text",
-                "maxIncomeEligibility": educational_input_kwargs["program_prerequisites"]["max_income_eligibility"]
-            },
-            {
-                "@type": "Text",
-                "otherProgramPrerequisites": educational_input_kwargs["program_prerequisites"]["other_program_prerequisites"]
-            }
-        ],
+        "programPrerequisites": {
+            "@type": "EducationalOccupationalCredential",
+            "credentialCategory": educational_input_kwargs["program_prerequisites"]["credential_category"],
+            "competencyRequired": educational_input_kwargs["program_prerequisites"]["competency_required"]
+        },
         "timeOfDay": educational_input_kwargs["time_of_day"]
     }
 

--- a/tests/helper/test_add_prerequisites.py
+++ b/tests/helper/test_add_prerequisites.py
@@ -3,31 +3,18 @@ import json
 import pytest
 from expects import equal, expect
 
-from converter.helper import add_prerequisite, add_prerequisites_data
+from converter.helper import add_prerequisites_data
 
 
 def test_add_prerequisites_data(work_based_input_kwargs):
     input_kwargs = work_based_input_kwargs["program_prerequisites"]
-    
+
     expected_output = {
-        "programPrerequisites": [
-            {
-                "@type": "EducationalOccupationalCredential",
-                "credentialCategory": work_based_input_kwargs["program_prerequisites"]["credential_category"]
-            },
-            {
-                "@type": "Text",
-                "eligibleGroups": work_based_input_kwargs["program_prerequisites"]["eligible_groups"]
-            },
-            {
-                "@type": "Text",
-                "maxIncomeEligibility": work_based_input_kwargs["program_prerequisites"]["max_income_eligibility"]
-            },
-            {
-                "@type": "Text",
-                "otherProgramPrerequisites": work_based_input_kwargs["program_prerequisites"]["other_program_prerequisites"]
-            }
-        ]
+        "programPrerequisites": {
+            "@type": "EducationalOccupationalCredential",
+            "credentialCategory": work_based_input_kwargs["program_prerequisites"]["credential_category"],
+            "competencyRequired": work_based_input_kwargs["program_prerequisites"]["competency_required"]
+        }
     }
 
     output = add_prerequisites_data({}, input_kwargs)
@@ -38,37 +25,49 @@ def test_add_prerequisites_data(work_based_input_kwargs):
     expect(json_output).to(equal(json_expected_output))
 
 
-def test_add_prerequisite_credential_category():
-    output = add_prerequisite({'programPrerequisites': []}, "credential_category", "HighSchool")
+def test_add_prerequisites_credential(work_based_input_kwargs):
+    input_kwargs = {
+        "credential_category": "HighSchool"
+    }
 
     expected_output = {
-        'programPrerequisites': [
-            {
-                '@type': 'EducationalOccupationalCredential', 
-                'credentialCategory': 'HighSchool'
-            }
-        ]
+        "programPrerequisites": {
+            "@type": "EducationalOccupationalCredential",
+            "credentialCategory": "HighSchool"
+        }
     }
-    
+
+    output = add_prerequisites_data({}, input_kwargs)
+
     json_expected_output = json.dumps(expected_output, sort_keys=True)
     json_output = json.dumps(output, sort_keys=True)
 
     expect(json_output).to(equal(json_expected_output))
 
 
-def test_add_prerequisite_other():
-    output = add_prerequisite({'programPrerequisites': []}, 'eligible_groups', 'Youth')
+def test_add_prerequisites_competency(work_based_input_kwargs):
+    input_kwargs = {
+        "competency_required": "Valid driver’s license"
+    }
 
     expected_output = {
-        'programPrerequisites': [
-            {
-                '@type': 'Text', 
-                'eligibleGroups': 'Youth'
-            }
-        ]
+        "programPrerequisites": {
+            "@type": "EducationalOccupationalCredential",
+            "competencyRequired": "Valid driver’s license"
+        }
     }
-    
+
+    output = add_prerequisites_data({}, input_kwargs)
+
     json_expected_output = json.dumps(expected_output, sort_keys=True)
     json_output = json.dumps(output, sort_keys=True)
 
     expect(json_output).to(equal(json_expected_output))
+
+
+def test_add_prerequisites_empty(work_based_input_kwargs):
+    input_kwargs = {}
+    expected_output = {}
+    output = add_prerequisites_data({}, input_kwargs)
+
+    expect(output).to(equal(expected_output))

--- a/tests/helper/test_other_helper_functions.py
+++ b/tests/helper/test_other_helper_functions.py
@@ -62,24 +62,11 @@ def test_add_data_keywords(work_based_input_kwargs, training_salary, salary_upon
                 "priceCurrency": "USD"
             }
         },
-        "programPrerequisites": [
-            {
-                "@type": "EducationalOccupationalCredential",
-                "credentialCategory": work_based_input_kwargs["program_prerequisites"]["credential_category"]
-            },
-            {
-                "@type": "Text",
-                "eligibleGroups": work_based_input_kwargs["program_prerequisites"]["eligible_groups"]
-            },
-            {
-                "@type": "Text",
-                "maxIncomeEligibility": work_based_input_kwargs["program_prerequisites"]["max_income_eligibility"]
-            },
-            {
-                "@type": "Text",
-                "otherProgramPrerequisites": work_based_input_kwargs["program_prerequisites"]["other_program_prerequisites"]
-            }
-        ],
+        "programPrerequisites": {
+            "@type": "EducationalOccupationalCredential",
+            "credentialCategory": work_based_input_kwargs["program_prerequisites"]["credential_category"],
+            "competencyRequired": work_based_input_kwargs["program_prerequisites"]["competency_required"]
+        },
         "provider": {
             "@type": "EducationalOrganization",
             "name": work_based_input_kwargs['provider_name'],

--- a/tests/work/test_main_work.py
+++ b/tests/work/test_main_work.py
@@ -37,24 +37,11 @@ def test_work_based_programs_converter_all(work_based_input_kwargs, offers, trai
         "endDate": work_based_input_kwargs['end_date'],
         "startDate": work_based_input_kwargs['start_date'],
         "maximumEnrollment": work_based_input_kwargs["maximum_enrollment"],
-        "programPrerequisites": [
-            {
-                "@type": "EducationalOccupationalCredential", 
-                "credentialCategory": work_based_input_kwargs["program_prerequisites"]["credential_category"]
-            },
-            {
-                "@type": "Text",
-                "eligibleGroups": work_based_input_kwargs["program_prerequisites"]["eligible_groups"]
-            },
-            {
-                "@type": "Text",
-                "maxIncomeEligibility": work_based_input_kwargs["program_prerequisites"]["max_income_eligibility"]
-            },
-            {
-                "@type": "Text",
-                "otherProgramPrerequisites": work_based_input_kwargs["program_prerequisites"]["other_program_prerequisites"]
-            }
-        ],
+        "programPrerequisites": {
+            "@type": "EducationalOccupationalCredential",
+            "credentialCategory": work_based_input_kwargs["program_prerequisites"]["credential_category"],
+            "competencyRequired": work_based_input_kwargs["program_prerequisites"]["competency_required"]
+        },
         "timeOfDay": work_based_input_kwargs["time_of_day"],
         "trainingSalary": training_salary,
         "salaryUponCompletion": salary_upon_completion,


### PR DESCRIPTION
# Description

This PR adjusts how the converter populates the `programPrerequisites` property. It closes card: https://app.clubhouse.io/brighthive/story/807/restrict-program-prerequisites-to-educationaloccupationalcredential

Code "walk-through" in bullet points:
* `add_prerequisites_data` accepts a dict and return Pathways-friendly JSON-LD
* the dict can have `credential_category` and/or `competency_required`; the dict can also be empty (in which case `add_prerequisites_data` should just return the existing json ld)

# Checklists

### Basic

- [x] Did you write tests for the code in this PR?
- [x] Did you document your changes in the README and/or in docstrings (as needed)?

# Notes for the Reviewer
Two requests:

1. Can you provide a quick code-quality check for me? [Python EAFP](https://docs.python.org/3/glossary.html) style sometimes seems clumsy.
2. The ["OccupationalCredential" object from Schema.org](https://schema.org/EducationalOccupationalCredential) can handle several properties. My solution only deals with `credentialCategory` and `competencyRequired`, because Goodwill can provide that data. I suppose we could add `educationalLevel`...but maybe we can handle that when we have more programs data (e.g., from JFF)? Thoughts?


# Other Notes
 It is unclear if Pathways expects the value of `credentialCategory` to have a particular format. Like, will Pathways accept "HighSchool" and "high school" and "highschool"? Something to keep an eye on.