### PR TITLE
fix: Add addressCountry to address blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You need to consider the following fields for the educational-occupational conve
 | **REQUIRED FIELDS**  
 | program_name          | String              
 | program_url           | String      
-| provider_address      | A list of dicts. Each dict should have at least one of the following keys: street_address, address_locality, address_region, postal_code.        
+| provider_address      | A list of dicts. Each dict should have the following keys: street_address, address_locality, address_region, postal_code, and address_country.
 | application_deadline  | String that represents a date value in ISO-8601 format
 | offers_price          | Integer
 | provider_name         | String
@@ -59,7 +59,7 @@ You need to consider the following fields for the work-based converter: `work_ba
 | **REQUIRED FIELDS**  
 | program_name          | String              
 | program_url           | String      
-| provider_address      | A list of dicts. Each dict should have at least one of the following keys: street_address, address_locality, address_region, postal_code. 
+| provider_address      | A list of dicts. Each dict should have the following keys: street_address, address_locality, address_region, postal_code, and address_country. 
 | program_description   | String
 | **RECOMMENDED FIELDS**   
 | program_description                | String
@@ -95,6 +95,7 @@ programs_input = {
             'street_address': '1 Grickle Grass Lane', 
             'address_locality': 'Springfield', 
             'address_region': 'MA', 
+            'address_country': 'US',
             'postal_code': '88881'
         }
     ], 
@@ -160,7 +161,8 @@ json.dumps(output, sort_keys=True)
             {
                 "@type": "PostalAddress", 
                 "addressLocality": "Springfield", 
-                "addressRegion": "MA", 
+                "addressRegion": "MA",
+                "addressCountry": "US", 
                 "postalCode": "88881", 
                 "streetAddress": "1 Grickle Grass Lane"
             }

--- a/converter/helper.py
+++ b/converter/helper.py
@@ -90,7 +90,8 @@ def add_address_data(json_ld: dict, address: dict) -> dict:
         "streetAddress": address.get("street_address", ""),
         "addressLocality": address.get("address_locality", ""),
         "addressRegion": address.get("address_region", ""),
-        "postalCode": address.get("postal_code", "")
+        "postalCode": address.get("postal_code", ""),
+        "addressCountry": address.get("address_country", "")
     }
 
     json_ld['provider']['address'].append(address_node)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def program_provider_address_data():
             "street_address": "1 Grickle Grass Lane",
             "address_locality": "Springfield",
             "address_region": "MA",
+            "address_country": "US",
             "postal_code": "88881"
         }
     ]

--- a/tests/education/test_main_education.py
+++ b/tests/education/test_main_education.py
@@ -38,6 +38,7 @@ def test_educational_occupational_converter_all(educational_input_kwargs, offers
                     "streetAddress": educational_input_kwargs["provider_address"][0]["street_address"],
                     "addressLocality": educational_input_kwargs["provider_address"][0]["address_locality"],
                     "addressRegion": educational_input_kwargs["provider_address"][0]["address_region"],
+                    "addressCountry": educational_input_kwargs["provider_address"][0]["address_country"],
                     "postalCode": educational_input_kwargs["provider_address"][0]["postal_code"]
                 }
             ],
@@ -107,6 +108,7 @@ def test_educational_occupational_converter_required(educational_input_kwargs, o
                     "streetAddress": educational_input_kwargs["provider_address"][0]["street_address"],
                     "addressLocality": educational_input_kwargs["provider_address"][0]["address_locality"],
                     "addressRegion": educational_input_kwargs["provider_address"][0]["address_region"],
+                    "addressCountry": educational_input_kwargs["provider_address"][0]["address_country"],
                     "postalCode": educational_input_kwargs["provider_address"][0]["postal_code"]
                 }
             ],

--- a/tests/helper/test_add_provider.py
+++ b/tests/helper/test_add_provider.py
@@ -23,6 +23,7 @@ def test_add_provider_data_all_fields(work_based_input_kwargs, program_provider_
                     "streetAddress": work_based_input_kwargs["provider_address"][0]["street_address"],
                     "addressLocality": work_based_input_kwargs["provider_address"][0]["address_locality"],
                     "addressRegion": work_based_input_kwargs["provider_address"][0]["address_region"],
+                    "addressCountry": work_based_input_kwargs["provider_address"][0]["address_country"],
                     "postalCode": work_based_input_kwargs["provider_address"][0]["postal_code"]
                 }
             ],
@@ -57,6 +58,7 @@ def test_add_provider_data_only_required_fields(work_based_input_kwargs, program
                     "streetAddress": work_based_input_kwargs["provider_address"][0]["street_address"],
                     "addressLocality": work_based_input_kwargs["provider_address"][0]["address_locality"],
                     "addressRegion": work_based_input_kwargs["provider_address"][0]["address_region"],
+                    "addressCountry": work_based_input_kwargs["provider_address"][0]["address_country"],
                     "postalCode": work_based_input_kwargs["provider_address"][0]["postal_code"]
                 }
             ],
@@ -84,6 +86,7 @@ def test_add_address_data(program_provider_address_data):
                     "streetAddress": program_provider_address_data[0]['street_address'],
                     "addressLocality": program_provider_address_data[0]['address_locality'],
                     "addressRegion": program_provider_address_data[0]['address_region'],
+                    "addressCountry": program_provider_address_data[0]['address_country'],
                     "postalCode": program_provider_address_data[0]['postal_code']
                 }
             ]
@@ -106,6 +109,7 @@ def test_add_address_data_empty_values():
                     "streetAddress": "",
                     "addressLocality": "",
                     "addressRegion": "",
+                    "addressCountry": "",
                     "postalCode": ""
                 }
             ]

--- a/tests/helper/test_other_helper_functions.py
+++ b/tests/helper/test_other_helper_functions.py
@@ -76,6 +76,7 @@ def test_add_data_keywords(work_based_input_kwargs, training_salary, salary_upon
                     "streetAddress": work_based_input_kwargs['provider_address'][0]['street_address'],
                     "addressLocality": work_based_input_kwargs['provider_address'][0]['address_locality'],
                     "addressRegion": work_based_input_kwargs['provider_address'][0]['address_region'],
+                    "addressCountry": work_based_input_kwargs['provider_address'][0]['address_country'],
                     "postalCode": work_based_input_kwargs['provider_address'][0]['postal_code']
                 }
             ],

--- a/tests/work/test_main_work.py
+++ b/tests/work/test_main_work.py
@@ -23,6 +23,7 @@ def test_work_based_programs_converter_all(work_based_input_kwargs, offers, trai
                     "streetAddress": work_based_input_kwargs['provider_address'][0]['street_address'],
                     "addressLocality": work_based_input_kwargs['provider_address'][0]['address_locality'],
                     "addressRegion": work_based_input_kwargs['provider_address'][0]['address_region'],
+                    "addressCountry": work_based_input_kwargs['provider_address'][0]['address_country'],
                     "postalCode": work_based_input_kwargs['provider_address'][0]['postal_code']
                 }
             ],
@@ -81,6 +82,7 @@ def test_work_based_programs_converter_required(work_based_input_kwargs):
                     "streetAddress": work_based_input_kwargs['provider_address'][0]['street_address'],
                     "addressLocality": work_based_input_kwargs['provider_address'][0]['address_locality'],
                     "addressRegion": work_based_input_kwargs['provider_address'][0]['address_region'],
+                    "addressCountry": work_based_input_kwargs['provider_address'][0]['address_country'],
                     "postalCode": work_based_input_kwargs['provider_address'][0]['postal_code']
                 }
             ],


### PR DESCRIPTION
# Description
This PR makes a quick fix to handle this card: https://app.clubhouse.io/brighthive/story/966/pathways-validation-fails-when-addresscountry-is-not-included