### PR TITLE
Ch1157/new field pathways requires occupationalcategory

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You need to consider the following fields for the educational-occupational conve
 | provider_telephone    | String
 | time_to_complete                   | String that represents a duration in ISO-8601 format
 | identifier_cip  AND/OR identifier_program_id | String
+| occupational_category | A list of strings. Each string must reference a [BLS SOC-6 code](https://www.bls.gov/soc/2010/home.htm), e.g., ["47-2111", "49-9021"].
 | **RECOMMENDED FIELDS**                
 | application_start_date             | String
 | start_date                         | String that represents a date in ISO-8601 format
@@ -62,6 +63,7 @@ You need to consider the following fields for the work-based converter: `work_ba
 | program_url           | String      
 | provider_address      | A list of dicts. Each dict should have the following keys: street_address, address_locality, address_region, postal_code, and address_country. 
 | program_description   | String
+| occupational_category | A list of strings. Each string must reference a [BLS SOC-6 code](https://www.bls.gov/soc/2010/home.htm), e.g., ["47-2111", "49-9021"].
 | **RECOMMENDED FIELDS**   
 | program_description                | String
 | provider_name                      | String

--- a/converter/converter.py
+++ b/converter/converter.py
@@ -28,7 +28,7 @@ class Converter():
         for kwarg in self.required_keywords:
             if kwarg not in kwargs.keys():
                 missing_kwargs.append(kwarg)
-            elif kwargs[kwarg] == '' or kwargs[kwarg] == None:
+            elif kwargs[kwarg] == '' or kwargs[kwarg] == None or kwargs[kwarg] == []:
                 missing_kwargs.append(kwarg)
 
         if missing_kwargs:

--- a/converter/education/educational_occupational_programs_converter.py
+++ b/converter/education/educational_occupational_programs_converter.py
@@ -3,7 +3,8 @@ from converter.helper import (add_educational_program_mode, add_header,
                               add_identifier_data, add_offers_data,
                               add_prerequisites_data, add_provider_data,
                               add_salary_upon_completion_data,
-                              add_training_salary_data, validate_occupational_category)
+                              add_training_salary_data,
+                              validate_occupational_category)
 
 # A list of keywords required for EducationalOccupationPrograms.
 required_keywords = [

--- a/converter/education/educational_occupational_programs_converter.py
+++ b/converter/education/educational_occupational_programs_converter.py
@@ -3,7 +3,7 @@ from converter.helper import (add_educational_program_mode, add_header,
                               add_identifier_data, add_offers_data,
                               add_prerequisites_data, add_provider_data,
                               add_salary_upon_completion_data,
-                              add_training_salary_data)
+                              add_training_salary_data, validate_occupational_category)
 
 # A list of keywords required for EducationalOccupationPrograms.
 required_keywords = [
@@ -17,6 +17,7 @@ required_keywords = [
     "provider_url", 
     "provider_telephone", 
     "time_to_complete", 
+    "occupational_category"
 ]
 
 kwarg_to_schema_key_mapper = {
@@ -29,6 +30,7 @@ data_keywords_mapper = {
     "program_prerequisites": lambda output, kwargs: add_prerequisites_data(output, kwargs.get('program_prerequisites')),
     "offers_price": lambda output, kwargs: add_offers_data(output, kwargs['offers_price']),
     "educational_program_mode": lambda output, kwargs: add_educational_program_mode(output, kwargs["educational_program_mode"]),
+    "occupational_category": lambda output, kwargs: validate_occupational_category(output, kwargs["occupational_category"]),
     "all": [
         lambda output, kwargs: add_header(output, "EducationalOccupationalProgram"),
         lambda output, kwargs: add_provider_data(output, kwargs),

--- a/converter/helper.py
+++ b/converter/helper.py
@@ -1,4 +1,5 @@
 import stringcase
+import re
 
 
 def add_header(pathways_program: dict, type_str: str) -> dict:
@@ -202,3 +203,24 @@ def add_educational_program_mode(pathways_program: dict, program_mode=None):
             raise ValueError('Invalid data! "educational_program_mode" must be one of the following: "in-person", "online", "hybrid".')
         
     return pathways_program
+
+
+def validate_occupational_category(pathways_program: dict, occupational_categories):
+    '''
+    `occupationalCategory` (Pathways field) expects a list of SOC values, as defined by the US Bureau of Labor Statistics.
+    This function only validates the *format* of the occupational categories provided in the kwargs; it does NOT
+    validate against the actual SOC system of values.
+    '''
+    valid_occupational_categories = []
+    for soc_category in occupational_categories:
+        match = re.match(r"^\d{2}-\d+$", soc_category)
+        if match:
+            valid_occupational_categories.append(soc_category)
+        else:
+            raise ValueError('Invalid data! The values in "occupational_category" must provide use the Standard Occupational Classification System from the US Bureau of Labor.')
+    
+    pathways_program["occupationalCategory"] = valid_occupational_categories
+
+    return pathways_program
+
+

--- a/converter/work/work_based_programs_converter.py
+++ b/converter/work/work_based_programs_converter.py
@@ -2,14 +2,15 @@ from converter.converter import Converter
 from converter.helper import (add_header, add_offers_data,
                               add_prerequisites_data, add_provider_data,
                               add_salary_upon_completion_data,
-                              add_training_salary_data)
+                              add_training_salary_data, validate_occupational_category)
 
 # A list of keywords required for WorkBasedPrograms.
 required_keywords = [
     "provider_address",
     "program_name",
     "program_description",
-    "program_url"
+    "program_url",
+    "occupational_category"
 ]
 
 kwarg_to_schema_key_mapper = {
@@ -23,6 +24,7 @@ data_keywords_mapper = {
     "offers_price": lambda output, kwargs: add_offers_data(output, kwargs['offers_price']),
     "training_salary": lambda output, kwargs: add_training_salary_data(output, kwargs['training_salary']),
     "salary_upon_completion": lambda output, kwargs: add_salary_upon_completion_data(output, kwargs['salary_upon_completion']),
+    "occupational_category": lambda output, kwargs: validate_occupational_category(output, kwargs["occupational_category"]),
     "all": [
         lambda output, kwargs: add_header(output, "WorkBasedProgram"),
         lambda output, kwargs: add_provider_data(output, kwargs)

--- a/converter/work/work_based_programs_converter.py
+++ b/converter/work/work_based_programs_converter.py
@@ -2,7 +2,8 @@ from converter.converter import Converter
 from converter.helper import (add_header, add_offers_data,
                               add_prerequisites_data, add_provider_data,
                               add_salary_upon_completion_data,
-                              add_training_salary_data, validate_occupational_category)
+                              add_training_salary_data,
+                              validate_occupational_category)
 
 # A list of keywords required for WorkBasedPrograms.
 required_keywords = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,8 @@ def work_based_input_kwargs(program_provider_address_data, offers, training_sala
         "time_to_complete": "P6M",
         "offers_price": offers['priceSpecification']['price'],
         "training_salary": training_salary['median'],
-        "salary_upon_completion": salary_upon_completion['median']
+        "salary_upon_completion": salary_upon_completion['median'],
+        "occupational_category": ["15-1152", "15-2021", "15-2031"]
     }
 
 
@@ -116,4 +117,5 @@ def educational_input_kwargs(program_provider_address_data, offers, training_sal
         "offers_price": offers['priceSpecification']['price'],
         "start_date": "2020-04-01",
         "time_of_day": "Evening",
+        "occupational_category": ["15-1152", "15-2021", "15-2031"]
     }

--- a/tests/education/test_main_education.py
+++ b/tests/education/test_main_education.py
@@ -61,7 +61,8 @@ def test_educational_occupational_converter_all(educational_input_kwargs, offers
             "credentialCategory": educational_input_kwargs["program_prerequisites"]["credential_category"],
             "competencyRequired": educational_input_kwargs["program_prerequisites"]["competency_required"]
         },
-        "timeOfDay": educational_input_kwargs["time_of_day"]
+        "timeOfDay": educational_input_kwargs["time_of_day"],
+        "occupationalCategory": ["15-1152", "15-2021", "15-2031"]
     }
 
     json_expected_output = json.dumps(expected_output, sort_keys=True)
@@ -82,7 +83,8 @@ def test_educational_occupational_converter_required(educational_input_kwargs, o
         "provider_telephone": educational_input_kwargs["provider_telephone"],
         "provider_address": educational_input_kwargs["provider_address"],
         "time_to_complete": educational_input_kwargs["time_to_complete"],
-        "identifier_program_id": educational_input_kwargs["identifier_program_id"]
+        "identifier_program_id": educational_input_kwargs["identifier_program_id"],
+        "occupational_category": ["15-1152", "15-2021", "15-2031"]
     }
     
     expected_output = {
@@ -120,7 +122,8 @@ def test_educational_occupational_converter_required(educational_input_kwargs, o
                 "telephone": educational_input_kwargs["provider_telephone"]
             }
         },
-        "timeToComplete": educational_input_kwargs["time_to_complete"]
+        "timeToComplete": educational_input_kwargs["time_to_complete"],
+        "occupationalCategory": ["15-1152", "15-2021", "15-2031"]
     }
 
     output = educational_occupational_programs_converter(**required_kwargs)

--- a/tests/work/test_main_work.py
+++ b/tests/work/test_main_work.py
@@ -47,6 +47,7 @@ def test_work_based_programs_converter_all(work_based_input_kwargs, offers, trai
         "trainingSalary": training_salary,
         "salaryUponCompletion": salary_upon_completion,
         "occupationalCredentialAwarded": work_based_input_kwargs["occupational_credential_awarded"],
+        "occupationalCategory": ["15-1152", "15-2021", "15-2031"]
     }
 
     json_expected_output = json.dumps(expected_output, sort_keys=True)
@@ -63,7 +64,8 @@ def test_work_based_programs_converter_required(work_based_input_kwargs):
         "provider_name": work_based_input_kwargs['provider_name'],
         "provider_url": work_based_input_kwargs['provider_url'],
         "provider_telephone": work_based_input_kwargs['provider_telephone'],
-        "provider_address": work_based_input_kwargs['provider_address']
+        "provider_address": work_based_input_kwargs['provider_address'],
+        "occupational_category": ["15-1152", "15-2021", "15-2031"]
     }
     output = work_based_programs_converter(**required_kwargs)
 
@@ -92,7 +94,8 @@ def test_work_based_programs_converter_required(work_based_input_kwargs):
                 "contactType": "Admissions",
                 "telephone": work_based_input_kwargs['provider_telephone']
             }
-        }
+        },
+        "occupationalCategory": ["15-1152", "15-2021", "15-2031"]
     }
 
     json_expected_output = json.dumps(expected_output, sort_keys=True)


### PR DESCRIPTION
# Description

Google Pathways added a new `required` field for Occupational and WorkBased programs: `occupationalCategory`.

The `occupationalCategory` must be a list of SOC values: https://www.bls.gov/soc/2010/2010_major_groups.htm

This PR includes *light* validation for SOC values. `validate_occupational_category` applies a regex against the individual values in the occupational_category list. Specifically, the regex insures that the SOC value the following: two digits, a hyphen, and additional digits. **It does not actually look-up the SOC value as defined by the US Bureau of Labor Statistics.**

Completes clubhouse card: https://app.clubhouse.io/brighthive/story/1157/new-field-pathways-requires-occupationalcategory

# Checklists

### Basic

- [x] Did you write tests for the code in this PR?
- [x] Did you document your changes in the README and/or in docstrings (as needed)?

# Notes for the Reviewer

@loganripplinger - two things would be helpful:

1. General code review – any smells? any opportunities to refactor?
2. Can you give your opinion on the validation? It is not perfect, but I think (for now) we should have *some* validation of SOC values, as opposed to *no* validation.